### PR TITLE
Update publishing instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-Smartyr Review embed project 
+Smartyr Review embed project
 
 Npm run start to start react app
 
 ##Viewing Live Version
 
+##Publishing updates,
 
-##Publishing updates, 
-1. Run build to update the dist/index.css and dist/index.js files.
-2. Pushing to github will update the files hosted on cdn. 
+1. From your local branch run build (npm run build) to update the dist/index.css and dist/index.js files.
+2. Then, create a PR to the main branch and push the changes to update the files hosted on cdn.


### PR DESCRIPTION
Clarified the steps for publishing updates, specifying to run build locally and create a PR to main before pushing changes to update CDN-hosted files.